### PR TITLE
[FEAT] 카카오 로그인 구현 완료 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,78 @@
 # 2024_DANPOONG_TEAM_3_BE
+
+## **브랜치 컨벤션**
+
+- `main` : default 브랜치
+- `기능을 개발하면서 각자가 사용할 브랜치`
+    - `[feat]` : 기능 추가
+    - `[fix]` : 에러 수정, 버그 수정
+    - `[refactor]` : 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
+    - `[modify]` : 코드 수정 (기능의 변화가 있을 때)
+    - `[chore]` : gradle 세팅, 위의 것 이외에 거의 모든 것
+    - 예시 : `feat/#3-social_login_api` ([ ]/#이슈번호-구현하려는 기능)
+
+## **커밋 컨벤션**
+
+- `[CHORE]` : 동작에 영향 없는 코드 or 변경 없는 변경사항(주석 추가 등) or 파일명, 폴더명 수정 or 파일, 폴더 삭제 or 디렉토리 구조 변경
+- `[FEAT]` : 새로운 기능 구현
+- `[ADD]` : Feat 이외의 부수적인 코드 추가, 라이브러리 추가, 새로운 파일 생성
+- `[FIX]` : 코드 수정, 버그/오류 해결
+- `[DEL]` : 쓸모없는 코드 삭제
+- `[DOCS]` : README나 WIKI 등의 문서 수정
+- `[REFACTOR]` : 전면 수정, 코드 리팩토링
+- `[MERGE]`: 다른 브랜치와 병합
+- `[DEPLOY]`: 배포 관련
+    - 예시 : `ex ) git commit -m "[FEAT] 회원가입 기능 완료 #이슈번호"`
+
+## **이슈 & PR 컨벤션**
+
+- `[FEAT]` : 기능 추가
+- `[FIX]` : 에러 수정, 버그 수정
+- `[CHORE]` : gradle 세팅, 위의 것 이외에 거의 모든 것
+- `[DOCS]` : README, 문서
+- `[REFACTOR]` : 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
+- `[MODIFY]` : 코드 수정 (기능의 변화가 있을 때)
+- **이슈/PR 생성 시 제목 형식은 위의 형식을 따를 것! → Assignees / Labels 선택**
+
+## **코드 컨벤션**
+
+1. 기본적으로 네이밍은 **누구나 알 수 있는 쉬운 단어**를 선택한다.
+    - 우리는 외국인이 아니다. 쓸데없이 어려운 고급 어휘를 피한다.
+2. 변수는 CamelCase를 기본으로 한다.
+    - userEmail, userCellPhone ...
+3. URL, 파일명 등은 kebab-case를 사용한다.
+    - /user-email-page ...
+4. 패키지명은 단어가 달라지더라도 무조건 소문자를 사용한다.
+    - frontend, useremail ...
+5. ENUM이나 상수는 대문자로 네이밍한다.
+    - NORMAL_STATUS ...
+6. 함수명은 소문자로 시작하고 **동사**로 네이밍한다.
+    - getUserId(), isNormal() ...
+7. 클래스명은 **명사**로 작성하고 UpperCamelCase를 사용한다.
+    - UserEmail, Address ...
+8. 객체 이름을 함수 이름에 중복해서 넣지 않는다. (= 상위 이름을 하위 이름에 중복시키지 않는다.)
+    - line.getLength() (O) / line.getLineLength() (X)
+9. 컬렉션은 복수형을 사용하거나 컬렉션을 명시해준다.
+    - List ids, Map<User, Int> userToIdMap ...
+10. 이중적인 의미를 가지는 단어는 지양한다.
+    - event, design ...
+11. 의도가 드러난다면 되도록 짧은 이름을 선택한다.
+    - retreiveUser() (X) / getUser() (O)
+    - 단, 축약형을 선택하는 경우는 개발자의 의도가 명백히 전달되는 경우이다. 명백히 전달이 안된다면 축약형보다 서술형이 더 좋다.
+12. 함수의 부수효과를 설명한다.
+    - 함수는 한가지 동작만 수행하는 것이 좋지만, 때에 따라 부수 효과를 일으킬 수도 있다.
+
+        ```
+        fun getOrder() {
+          if (order == null) {
+              order = Order()
+          }
+        return order
+        }
+        
+        ```
+
+    - 위 함수는 단순히 order만 가져오는 것이 아니라, 없으면 생성해서 리턴한다.
+    - 그러므로 getOrder() (X) / getOrCreateOrder() (O)
+13. LocalDateTime -> xxxAt, LocalDate -> xxxDt로 네이밍
+14. 객체를 조회하는 함수는 JPA Repository에서 findXxx 형식의 네이밍 쿼리메소드를 사용하므로 개발자가 작성하는 Service단에서는 되도록이면 getXxx를 사용하자.

--- a/build.gradle
+++ b/build.gradle
@@ -43,11 +43,23 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	// AWS S3
     implementation platform('software.amazon.awssdk:bom:2.20.56')
 	implementation 'software.amazon.awssdk:s3'
+
+	//JWT
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+	implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
+	//Validation
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	//Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-web-services'
+
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/outofcity/server/controller/member/BusinessMemberController.java
+++ b/src/main/java/com/outofcity/server/controller/member/BusinessMemberController.java
@@ -1,0 +1,34 @@
+package com.outofcity.server.controller.member;
+
+import com.outofcity.server.dto.member.business.request.BusinessMemberRequestDto;
+import com.outofcity.server.dto.member.business.response.BusinessMemberResponseDto;
+import com.outofcity.server.global.exception.dto.SuccessStatusResponse;
+import com.outofcity.server.global.exception.message.SuccessMessage;
+import com.outofcity.server.service.BusinessMemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class BusinessMemberController {
+
+    private final BusinessMemberService businessMemberService;
+
+    @PostMapping("register/business")
+    public ResponseEntity<SuccessStatusResponse<BusinessMemberResponseDto>> registerBusiness(@RequestBody BusinessMemberRequestDto businessMemberRequestDto) {
+        return ResponseEntity.status(HttpStatus.OK).body(
+                SuccessStatusResponse.of(
+                        SuccessMessage.SIGNUP_SUCCESS, businessMemberService.registerBusiness(businessMemberRequestDto)
+                )
+        );
+    }
+
+}

--- a/src/main/java/com/outofcity/server/controller/member/KakaoLoginController.java
+++ b/src/main/java/com/outofcity/server/controller/member/KakaoLoginController.java
@@ -4,12 +4,12 @@ import com.outofcity.server.domain.GeneralMember;
 import com.outofcity.server.dto.member.kakaologin.response.SuccessLoginResponseDto;
 import com.outofcity.server.global.exception.dto.oauth.KakaoUserInfoResponseDto;
 import com.outofcity.server.service.KakaoLoginService;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -22,17 +22,14 @@ public class KakaoLoginController {
     public ResponseEntity<?> callback(@RequestParam("code") String code) {
         // 1. 코드로 Access Token 발급
         String accessToken = kakaoLoginService.getAccessTokenFromKakao(code);
-
+        log.info("accessToken: {}", accessToken);
         // 2. Access Token으로 사용자 정보 가져오기
         KakaoUserInfoResponseDto userInfo = kakaoLoginService.getUserInfo(accessToken);
 
         // 3. 사용자 로그인 또는 회원가입 처리
-        SuccessLoginResponseDto successLoginResponseDto = kakaoLoginService.findUser(userInfo);
+        SuccessLoginResponseDto successLoginResponseDto = kakaoLoginService.findUser(userInfo, accessToken);
 
-        // 4. 메인 페이지로 리다이렉트
-        // HttpServletResponse를 통해 리다이렉트 가능
-        return ResponseEntity.status(HttpStatus.FOUND)
-                .header(HttpHeaders.LOCATION, "https://outofcity.site")
-                .build();
+        // 5. 메인 페이지로 리다이렉트
+        return ResponseEntity.ok(successLoginResponseDto);
     }
 }

--- a/src/main/java/com/outofcity/server/controller/member/KakaoLoginController.java
+++ b/src/main/java/com/outofcity/server/controller/member/KakaoLoginController.java
@@ -1,17 +1,18 @@
 package com.outofcity.server.controller.member;
 
-import com.outofcity.server.domain.GeneralMember;
 import com.outofcity.server.dto.member.kakaologin.response.SuccessLoginResponseDto;
 import com.outofcity.server.global.exception.dto.SuccessStatusResponse;
 import com.outofcity.server.global.exception.dto.oauth.KakaoUserInfoResponseDto;
 import com.outofcity.server.global.exception.message.SuccessMessage;
 import com.outofcity.server.service.KakaoLoginService;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController

--- a/src/main/java/com/outofcity/server/controller/member/KakaoLoginController.java
+++ b/src/main/java/com/outofcity/server/controller/member/KakaoLoginController.java
@@ -2,11 +2,14 @@ package com.outofcity.server.controller.member;
 
 import com.outofcity.server.domain.GeneralMember;
 import com.outofcity.server.dto.member.kakaologin.response.SuccessLoginResponseDto;
+import com.outofcity.server.global.exception.dto.SuccessStatusResponse;
 import com.outofcity.server.global.exception.dto.oauth.KakaoUserInfoResponseDto;
+import com.outofcity.server.global.exception.message.SuccessMessage;
 import com.outofcity.server.service.KakaoLoginService;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,7 +22,7 @@ public class KakaoLoginController {
     private final KakaoLoginService kakaoLoginService;
 
     @GetMapping("/callback")
-    public ResponseEntity<?> callback(@RequestParam("code") String code) {
+    public ResponseEntity<SuccessStatusResponse<SuccessLoginResponseDto>> callback(@RequestParam("code") String code) {
         // 1. 코드로 Access Token 발급
         String accessToken = kakaoLoginService.getAccessTokenFromKakao(code);
         log.info("accessToken: {}", accessToken);
@@ -30,6 +33,10 @@ public class KakaoLoginController {
         SuccessLoginResponseDto successLoginResponseDto = kakaoLoginService.findUser(userInfo, accessToken);
 
         // 5. 메인 페이지로 리다이렉트
-        return ResponseEntity.ok(successLoginResponseDto);
+        return ResponseEntity.status(HttpStatus.OK).body(
+                SuccessStatusResponse.of(
+                        SuccessMessage.SIGNIN_SUCCESS, successLoginResponseDto
+                )
+        );
     }
 }

--- a/src/main/java/com/outofcity/server/controller/member/KakaoLoginController.java
+++ b/src/main/java/com/outofcity/server/controller/member/KakaoLoginController.java
@@ -1,0 +1,38 @@
+package com.outofcity.server.controller.member;
+
+import com.outofcity.server.domain.GeneralMember;
+import com.outofcity.server.dto.member.kakaologin.response.SuccessLoginResponseDto;
+import com.outofcity.server.global.exception.dto.oauth.KakaoUserInfoResponseDto;
+import com.outofcity.server.service.KakaoLoginService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class KakaoLoginController {
+
+    private final KakaoLoginService kakaoLoginService;
+
+    @GetMapping("/callback")
+    public ResponseEntity<?> callback(@RequestParam("code") String code) {
+        // 1. 코드로 Access Token 발급
+        String accessToken = kakaoLoginService.getAccessTokenFromKakao(code);
+
+        // 2. Access Token으로 사용자 정보 가져오기
+        KakaoUserInfoResponseDto userInfo = kakaoLoginService.getUserInfo(accessToken);
+
+        // 3. 사용자 로그인 또는 회원가입 처리
+        SuccessLoginResponseDto successLoginResponseDto = kakaoLoginService.findUser(userInfo);
+
+        // 4. 메인 페이지로 리다이렉트
+        // HttpServletResponse를 통해 리다이렉트 가능
+        return ResponseEntity.status(HttpStatus.FOUND)
+                .header(HttpHeaders.LOCATION, "https://outofcity.site")
+                .build();
+    }
+}

--- a/src/main/java/com/outofcity/server/domain/BusinessMember.java
+++ b/src/main/java/com/outofcity/server/domain/BusinessMember.java
@@ -1,13 +1,12 @@
 package com.outofcity.server.domain;
 
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import jakarta.persistence.*;
-import java.time.LocalDate;
+
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Entity
 @Getter

--- a/src/main/java/com/outofcity/server/domain/GeneralMember.java
+++ b/src/main/java/com/outofcity/server/domain/GeneralMember.java
@@ -16,7 +16,6 @@ import java.util.List;
 public class GeneralMember {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "general_member_id")
     private Long generalMemberId;
 
@@ -33,15 +32,17 @@ public class GeneralMember {
     private String email;
 
     @Builder
-    public GeneralMember(String name, String rank, String profileImageUrl, String email) {
+    public GeneralMember(Long id, String name, String rank, String profileImageUrl, String email) {
+        this.generalMemberId = id;
         this.name = name;
         this.rank = rank;
         this.profileImageUrl = profileImageUrl;
         this.email = email;
     }
 
-    public GeneralMember of(String name, String rank, String profileImageUrl, String email) {
+    public GeneralMember of(Long id, String name, String rank, String profileImageUrl, String email) {
         return GeneralMember.builder()
+                .id(id)
                 .name(name)
                 .rank(rank)
                 .profileImageUrl(profileImageUrl)

--- a/src/main/java/com/outofcity/server/dto/member/business/request/BusinessMemberRequestDto.java
+++ b/src/main/java/com/outofcity/server/dto/member/business/request/BusinessMemberRequestDto.java
@@ -1,0 +1,14 @@
+package com.outofcity.server.dto.member.business.request;
+
+public record BusinessMemberRequestDto (
+    String businessName,
+    Long businessNumber,
+    String businessAddress,
+    String businessStartDate,
+    String businessPhoneNumber,
+    String businessEmail
+){
+    public static BusinessMemberRequestDto of(String businessName, Long businessNumber, String businessAddress, String businessStartDate, String businessPhoneNumber, String businessEmail) {
+        return new BusinessMemberRequestDto(businessName, businessNumber, businessAddress, businessStartDate, businessPhoneNumber, businessEmail);
+    }
+}

--- a/src/main/java/com/outofcity/server/dto/member/business/response/BusinessMemberResponseDto.java
+++ b/src/main/java/com/outofcity/server/dto/member/business/response/BusinessMemberResponseDto.java
@@ -1,8 +1,5 @@
 package com.outofcity.server.dto.member.business.response;
 
-import com.outofcity.server.global.exception.message.ErrorMessage;
-import com.outofcity.server.global.exception.message.SuccessMessage;
-
 import java.time.LocalDateTime;
 
 public record BusinessMemberResponseDto(

--- a/src/main/java/com/outofcity/server/dto/member/business/response/BusinessMemberResponseDto.java
+++ b/src/main/java/com/outofcity/server/dto/member/business/response/BusinessMemberResponseDto.java
@@ -1,0 +1,17 @@
+package com.outofcity.server.dto.member.business.response;
+
+import com.outofcity.server.global.exception.message.ErrorMessage;
+import com.outofcity.server.global.exception.message.SuccessMessage;
+
+import java.time.LocalDateTime;
+
+public record BusinessMemberResponseDto(
+        Long id,
+        String businessName,
+        Long businessNumber,
+        String businessAddress,
+        LocalDateTime businessStartDate,
+        String businessPhoneNumber,
+        String businessEmail
+){
+}

--- a/src/main/java/com/outofcity/server/dto/member/kakaologin/response/SuccessLoginResponseDto.java
+++ b/src/main/java/com/outofcity/server/dto/member/kakaologin/response/SuccessLoginResponseDto.java
@@ -11,13 +11,15 @@ public class SuccessLoginResponseDto {
     private String rank;
     private String profileImageUrl;
     private String email;
+    private String jwtToken;
 
     @Builder
-    public SuccessLoginResponseDto(Long id, String name, String rank, String profileImageUrl, String email) {
+    public SuccessLoginResponseDto(Long id, String name, String rank, String profileImageUrl, String email, String jwtToken) {
         this.id = id;
         this.name = name;
         this.rank = rank;
         this.profileImageUrl = profileImageUrl;
         this.email = email;
+        this.jwtToken = jwtToken;
     }
 }

--- a/src/main/java/com/outofcity/server/dto/member/kakaologin/response/SuccessLoginResponseDto.java
+++ b/src/main/java/com/outofcity/server/dto/member/kakaologin/response/SuccessLoginResponseDto.java
@@ -1,0 +1,23 @@
+package com.outofcity.server.dto.member.kakaologin.response;
+
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SuccessLoginResponseDto {
+
+    private Long id;
+    private String name;
+    private String rank;
+    private String profileImageUrl;
+    private String email;
+
+    @Builder
+    public SuccessLoginResponseDto(Long id, String name, String rank, String profileImageUrl, String email) {
+        this.id = id;
+        this.name = name;
+        this.rank = rank;
+        this.profileImageUrl = profileImageUrl;
+        this.email = email;
+    }
+}

--- a/src/main/java/com/outofcity/server/global/exception/auth/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/outofcity/server/global/exception/auth/CustomAccessDeniedHandler.java
@@ -1,0 +1,24 @@
+package com.outofcity.server.global.exception.auth;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+// 인가 실패 Handler
+// 인가 과정을 지금 구현하진 않음
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        setResponse(response);
+    }
+
+    private void setResponse(HttpServletResponse response) {
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+    }
+}

--- a/src/main/java/com/outofcity/server/global/exception/auth/CustomJwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/outofcity/server/global/exception/auth/CustomJwtAuthenticationEntryPoint.java
@@ -1,0 +1,39 @@
+package com.outofcity.server.global.exception.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.outofcity.server.global.exception.dto.ErrorResponse;
+import com.outofcity.server.global.exception.message.ErrorMessage;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+// 필터에서 인증이나 인가를 통과하지 못했을 때, 이를 Handle할 Handler클래스
+// 인증에 실패한 경우 Unauthorized 상태를 반환해줄 EntryPoint
+@Component
+@RequiredArgsConstructor
+public class CustomJwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        setResponse(response);
+    }
+
+    private void setResponse(HttpServletResponse response) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter()
+            .write(objectMapper.writeValueAsString(
+                ErrorResponse.of(ErrorMessage.JWT_UNAUTHORIZED_EXCEPTION.getCode(),
+                    ErrorMessage.JWT_UNAUTHORIZED_EXCEPTION.getMessage())));
+    }
+    // Filter에서 예외가 발생했을 경우 Response를 커스텀해서 리턴
+}

--- a/src/main/java/com/outofcity/server/global/exception/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/outofcity/server/global/exception/auth/JwtAuthenticationFilter.java
@@ -1,0 +1,61 @@
+package com.outofcity.server.global.exception.auth;
+
+import com.outofcity.server.global.exception.UnauthorizedException;
+import com.outofcity.server.global.exception.message.ErrorMessage;
+import com.outofcity.server.global.jwt.JwtTokenProvider;
+import com.outofcity.server.global.jwt.UserAuthentication;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.constraints.NotNull;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+import static com.outofcity.server.global.jwt.JwtValidationType.VALID_JWT;
+
+
+// 요청에서 Jwt를 검증하는 커스텀 필터 클래스
+@Component // 필터를 빈으로 등록
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter  { // 요청이 주어졌을때 한번만 수행되는 필터를 상속받음
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(@NotNull HttpServletRequest request,
+                                    @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain filterChain) throws ServletException, IOException {
+        try {
+            final String token = getJwtFromRequest(request);
+            if (jwtTokenProvider.validateToken(token) == VALID_JWT) { // 추출한 토큰의 정보가 VALID_JWT일 경우 사용자 정보 추출
+                Long memberId = jwtTokenProvider.getUserFromJwt(token);
+
+                UserAuthentication authentication = UserAuthentication.createUserAuthentication(memberId);
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                // 추출한 UserId 기반 authentication 객체 생성
+
+                SecurityContextHolder.getContext().setAuthentication(authentication); // SecurityContextHolder에 User 정보 저장
+            }
+        } catch (Exception exception) {
+            throw new UnauthorizedException(ErrorMessage.JWT_UNAUTHORIZED_EXCEPTION); // 토큰 추출 과정에서 에러 발생 시 UnauthorizedException 발생
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    // Request에서 Token을 추출하는 메서드
+    private String getJwtFromRequest(HttpServletRequest request) {
+        String token = request.getHeader("Authorization"); // Request의 Authorization 헤더값 추출
+        if (StringUtils.hasText(token)) {
+            return token; // Bearer 없이 AccessToken을 반환
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/outofcity/server/global/exception/auth/PrincipalHandler.java
+++ b/src/main/java/com/outofcity/server/global/exception/auth/PrincipalHandler.java
@@ -1,0 +1,29 @@
+package com.outofcity.server.global.exception.auth;
+
+import com.outofcity.server.global.exception.UnauthorizedException;
+import com.outofcity.server.global.exception.message.ErrorMessage;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+//  member의 식별자를 가져오기 위한 클래스
+@Component
+public class PrincipalHandler {
+
+    private static final String ANONYMOUS_USER = "anonymousUser";
+
+    public Long getUserIdFromPrincipal() {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        // SecurityContextHolder에 저장되어 있는 Authetication객체를 추출하여 식별자를 꺼냄
+        isPrincipalNull(principal);
+        return Long.valueOf(principal.toString());
+    }
+
+    public void isPrincipalNull(
+        final Object principal
+    ) {
+        if (principal.toString().equals(ANONYMOUS_USER)) {
+            throw new UnauthorizedException(ErrorMessage.JWT_UNAUTHORIZED_EXCEPTION);
+        }
+        // 만일 Principal에 아무것도 담겨있지 않으면 AnonymousUser를 리턴함 -> 이럴 경우 예외를 발생
+    }
+}

--- a/src/main/java/com/outofcity/server/global/exception/auth/SecurityConfig.java
+++ b/src/main/java/com/outofcity/server/global/exception/auth/SecurityConfig.java
@@ -1,4 +1,5 @@
 package com.outofcity.server.global.exception.auth;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,8 +11,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
@@ -22,7 +21,7 @@ public class SecurityConfig {
     private final CustomJwtAuthenticationEntryPoint customJwtAuthenticationEntryPoint;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
 
-    private static final String[] AUTH_WHITE_LIST = {"/api/callback" };
+    private static final String[] AUTH_WHITE_LIST = {"/api/callback", "/api/register/business", "/api/s3", "/api/activities/recommend", "/api/activities/popular"};
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {

--- a/src/main/java/com/outofcity/server/global/exception/auth/SecurityConfig.java
+++ b/src/main/java/com/outofcity/server/global/exception/auth/SecurityConfig.java
@@ -1,0 +1,52 @@
+package com.outofcity.server.global.exception.auth;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.RequestCacheConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CustomJwtAuthenticationEntryPoint customJwtAuthenticationEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
+
+    private static final String[] AUTH_WHITE_LIST = {"/api/callback" };
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .requestCache(RequestCacheConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .exceptionHandling(exception -> {
+                    exception.authenticationEntryPoint(customJwtAuthenticationEntryPoint);
+                    exception.accessDeniedHandler(customAccessDeniedHandler);
+                })
+                .authorizeHttpRequests(auth -> {
+                    auth.requestMatchers(AUTH_WHITE_LIST).permitAll();
+                    auth.anyRequest().authenticated();
+                })
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+}

--- a/src/main/java/com/outofcity/server/global/exception/dto/oauth/KakaoLoginResponse.java
+++ b/src/main/java/com/outofcity/server/global/exception/dto/oauth/KakaoLoginResponse.java
@@ -1,0 +1,20 @@
+package com.outofcity.server.global.exception.dto.oauth;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+@Builder
+public class KakaoLoginResponse {
+    private final Long id;
+    private final String name;
+    private final String rank;
+    private final String profileImageUrl;
+    private final String email;
+
+    public static KakaoLoginResponse of(Long id, String name, String rank, String profileImageUrl, String email) {
+        return new KakaoLoginResponse(id, name, rank, profileImageUrl, email);
+    }
+}

--- a/src/main/java/com/outofcity/server/global/exception/dto/oauth/KakaoTokenResponseDto.java
+++ b/src/main/java/com/outofcity/server/global/exception/dto/oauth/KakaoTokenResponseDto.java
@@ -1,0 +1,61 @@
+package com.outofcity.server.global.exception.dto.oauth;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoTokenResponseDto {
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("id_token")
+    private String idToken;
+
+    @JsonProperty("expires_in")
+    private Integer expiresIn;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("refresh_token_expires_in")
+    private Integer refreshTokenExpiresIn;
+
+    @JsonProperty("scope")
+    private String scope;
+
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public void setTokenType(String tokenType) {
+        this.tokenType = tokenType;
+    }
+
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    public void setIdToken(String idToken) {
+        this.idToken = idToken;
+    }
+
+    public void setExpiresIn(Integer expiresIn) {
+        this.expiresIn = expiresIn;
+    }
+
+    public void setScope(String scope) {
+        this.scope = scope;
+    }
+
+    public void setRefreshTokenExpiresIn(Integer refreshTokenExpiresIn) {
+        this.refreshTokenExpiresIn = refreshTokenExpiresIn;
+    }
+}

--- a/src/main/java/com/outofcity/server/global/exception/dto/oauth/KakaoUserInfoResponseDto.java
+++ b/src/main/java/com/outofcity/server/global/exception/dto/oauth/KakaoUserInfoResponseDto.java
@@ -1,0 +1,62 @@
+package com.outofcity.server.global.exception.dto.oauth;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoUserInfoResponseDto {
+    @JsonProperty("id")
+    private Long id;
+
+    @JsonProperty("connected_at")
+    private String connectedAt;
+
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
+
+    @JsonProperty("properties")
+    private KakaoProperties properties;
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class KakaoAccount {
+        @JsonProperty("email")
+        private String email;
+
+        @JsonProperty("profile")
+        private KakaoProfile profile;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class KakaoProperties {
+        @JsonProperty("nickname")
+        private String nickname;
+
+        @JsonProperty("profile_image")
+        private String profileImage;
+
+        @JsonProperty("thumbnail_image")
+        private String thumbnailImage;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class KakaoProfile {
+        @JsonProperty("nickname")
+        private String nickname;
+
+        @JsonProperty("profile_image_url")
+        private String profileImageUrl;
+
+        @JsonProperty("thumbnail_image_url")
+        private String thumbnailImageUrl;
+    }
+}

--- a/src/main/java/com/outofcity/server/global/exception/message/ErrorMessage.java
+++ b/src/main/java/com/outofcity/server/global/exception/message/ErrorMessage.java
@@ -17,7 +17,10 @@ public enum ErrorMessage {
     DEACTIVATED_ACCOUNT(HttpStatus.FORBIDDEN.value(), "탈퇴된 계정입니다."),
     NOT_SUPPORTED_MEDIA_TYPE_ERROR(HttpStatus.BAD_REQUEST.value(), "지원하지 않는 파일 형식입니다."),
     BAD_IMAGE_FILE(HttpStatus.BAD_REQUEST.value(), "파일에 문제가 있습니다."),
-    UNDETERMINED_FILE(HttpStatus.BAD_REQUEST.value(), "식별할 수 없는 파일입니다."),;
+    UNDETERMINED_FILE(HttpStatus.BAD_REQUEST.value(), "식별할 수 없는 파일입니다."),
+    DUPLICATE_BUSINESS_MEMBER(HttpStatus.CONFLICT.value(), "이미 가입한 사업자입니다."),
+    INVALID_DATE(HttpStatus.NO_CONTENT.value(), "날짜 형식이 잘못되었습니다."),
+    DATABASE_ERROR(HttpStatus.CONFLICT.value(), "데이터베이스 오류가 발생했습니다."),;
     private final int code;
     private final String message;
 }

--- a/src/main/java/com/outofcity/server/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/outofcity/server/global/jwt/JwtTokenProvider.java
@@ -1,0 +1,86 @@
+package com.outofcity.server.global.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Base64;
+import java.util.Date;
+
+@Component // TokenProvider 클래스를 빈으로 등록
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    private static final String USER_ID = "generalMemberId";
+
+    private static final Long ACCESS_TOKEN_EXPIRATION_TIME = 24 * 60 * 60 * 1000L * 14; // 토큰 만료시간 설정
+
+    @Value("${jwt.secret}") // application.yml 파일에 설정한 암호화 키를 가져옴
+    private String JWT_SECRET;
+
+
+    // Authentication 객체로 AccessToken 발행
+    public String issueAccessToken(final Authentication authentication) { // Authentication 객체 : 인증 주체(로그인하는 사용자)를 설명하기 위한 Spring Security의 인터페이스
+        return generateToken(authentication, ACCESS_TOKEN_EXPIRATION_TIME);
+    }
+
+    /*
+    사용자 정보를 포함한 JWT를 생성하여 반환
+    JWT에는 발행 시간, 만료 시간, 사용자 ID 등의 정보가 포함
+    반환된 JWT는 응답으로 클라이언트에게 전달되거나, 클라이언트가 인증이 필요한 요청을 할 때 사용
+    */
+    public String generateToken(Authentication authentication, Long tokenExpirationTime) {
+        final Date now = new Date();
+        final Claims claims = Jwts.claims()
+                                  .setIssuedAt(now)
+                                  .setExpiration(new Date(now.getTime() + tokenExpirationTime)); // 만료 시간 설정
+
+        claims.put(USER_ID, authentication.getPrincipal());
+
+        return Jwts.builder()
+                   .setHeaderParam(Header.TYPE, Header.JWT_TYPE)  // Header 설정
+                   .setClaims(claims)  // Claim 설정
+                   .signWith(getSigningKey())  // 서명(Signature) 설정
+                   .setIssuer("OutOfCity")
+                   .compact();  // 최종적으로 JWT 토큰을 생성
+    }
+
+    private SecretKey getSigningKey() {
+        String encodedKey = Base64.getEncoder().encodeToString(JWT_SECRET.getBytes()); //SecretKey 통해 서명 생성
+        return Keys.hmacShaKeyFor(encodedKey.getBytes());   //일반적으로 HMAC (Hash-based Message Authentication Code) 알고리즘 사용 -> 암호화 키 생성
+    }
+
+    // Token에서 Claim을 추출하는 과정에서 에러가 발생하면 catch한후 validation 진행
+    public JwtValidationType validateToken(String token) {
+        try {
+            final Claims claims = getBody(token);
+            return JwtValidationType.VALID_JWT;
+        } catch (MalformedJwtException ex) {
+            return JwtValidationType.INVALID_JWT_TOKEN;
+        } catch (ExpiredJwtException ex) {
+            return JwtValidationType.EXPIRED_JWT_TOKEN;
+        } catch (UnsupportedJwtException ex) {
+            return JwtValidationType.UNSUPPORTED_JWT_TOKEN;
+        } catch (IllegalArgumentException ex) {
+            return JwtValidationType.EMPTY_JWT;
+        }
+    }
+
+    private Claims getBody(final String token) {
+        return Jwts.parserBuilder()
+                   .setSigningKey(getSigningKey())
+                   .build()
+                   .parseClaimsJws(token)
+                   .getBody();
+    }
+
+    // Token의 Claim에서 userId 값을 추출
+    public Long getUserFromJwt(String token) {
+        Claims claims = getBody(token);
+        return Long.valueOf(claims.get(USER_ID).toString());
+    }
+}

--- a/src/main/java/com/outofcity/server/global/jwt/JwtValidationType.java
+++ b/src/main/java/com/outofcity/server/global/jwt/JwtValidationType.java
@@ -1,0 +1,9 @@
+package com.outofcity.server.global.jwt;
+
+public enum JwtValidationType {
+    VALID_JWT,              // 유효한 JWT
+    INVALID_JWT_TOKEN,          // 유효하지 않은 토큰
+    EXPIRED_JWT_TOKEN,          // 만료된 토큰
+    UNSUPPORTED_JWT_TOKEN,      // 지원하지 않는 형식의 토큰
+    EMPTY_JWT                   // 빈 JWT
+}

--- a/src/main/java/com/outofcity/server/global/jwt/UserAuthentication.java
+++ b/src/main/java/com/outofcity/server/global/jwt/UserAuthentication.java
@@ -1,0 +1,20 @@
+package com.outofcity.server.global.jwt;
+
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+public class UserAuthentication extends UsernamePasswordAuthenticationToken {
+    // UsernamePasswordAuthenticationToken은 Authentication의 구현체로 Spring Security에서 Username/Password로 인증을 수행하기 위해 필요한 토큰
+
+    // UsernamePasswordAuthenticationToken은 식별자를 담을 수 있는 객체가 아니기 때문에 상속받아 Principle에 식별자를 담아줌
+    public UserAuthentication(Object principal, Object credentials, Collection<? extends GrantedAuthority> authorities) {
+        super(principal, credentials, authorities);
+    }
+
+    public static UserAuthentication createUserAuthentication(Long userId) {
+        return new UserAuthentication(userId, null, null);
+    }
+}

--- a/src/main/java/com/outofcity/server/repository/BusinessMemberRepository.java
+++ b/src/main/java/com/outofcity/server/repository/BusinessMemberRepository.java
@@ -1,0 +1,8 @@
+package com.outofcity.server.repository;
+
+import com.outofcity.server.domain.BusinessMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BusinessMemberRepository extends JpaRepository<BusinessMember, Long> {
+    BusinessMember findByBusinessNumber(Long businessNumber);
+}

--- a/src/main/java/com/outofcity/server/repository/GeneralMemberRepository.java
+++ b/src/main/java/com/outofcity/server/repository/GeneralMemberRepository.java
@@ -1,8 +1,16 @@
 package com.outofcity.server.repository;
 
 import com.outofcity.server.domain.GeneralMember;
+import com.outofcity.server.global.exception.BusinessException;
+import com.outofcity.server.global.exception.message.ErrorMessage;
+import com.outofcity.server.global.jwt.JwtTokenProvider;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface GeneralMemberRepository extends JpaRepository<GeneralMember, Long> {
+
+    default GeneralMember findByToken(String token, JwtTokenProvider jwtTokenProvider) {
+        return findById(jwtTokenProvider.getUserFromJwt(token))
+                .orElseThrow(() -> new BusinessException(ErrorMessage.NOT_FOUND_USER)); // userId로 User 객체 조회
+    }
 
 }

--- a/src/main/java/com/outofcity/server/repository/GeneralMemberRepository.java
+++ b/src/main/java/com/outofcity/server/repository/GeneralMemberRepository.java
@@ -1,0 +1,8 @@
+package com.outofcity.server.repository;
+
+import com.outofcity.server.domain.GeneralMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GeneralMemberRepository extends JpaRepository<GeneralMember, Long> {
+
+}

--- a/src/main/java/com/outofcity/server/service/BusinessMemberService.java
+++ b/src/main/java/com/outofcity/server/service/BusinessMemberService.java
@@ -5,7 +5,6 @@ import com.outofcity.server.dto.member.business.request.BusinessMemberRequestDto
 import com.outofcity.server.dto.member.business.response.BusinessMemberResponseDto;
 import com.outofcity.server.global.exception.BusinessException;
 import com.outofcity.server.global.exception.message.ErrorMessage;
-import com.outofcity.server.global.exception.message.SuccessMessage;
 import com.outofcity.server.repository.BusinessMemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/outofcity/server/service/BusinessMemberService.java
+++ b/src/main/java/com/outofcity/server/service/BusinessMemberService.java
@@ -1,0 +1,74 @@
+package com.outofcity.server.service;
+
+import com.outofcity.server.domain.BusinessMember;
+import com.outofcity.server.dto.member.business.request.BusinessMemberRequestDto;
+import com.outofcity.server.dto.member.business.response.BusinessMemberResponseDto;
+import com.outofcity.server.global.exception.BusinessException;
+import com.outofcity.server.global.exception.message.ErrorMessage;
+import com.outofcity.server.global.exception.message.SuccessMessage;
+import com.outofcity.server.repository.BusinessMemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+@Service
+@Slf4j
+@Transactional
+@RequiredArgsConstructor
+public class BusinessMemberService {
+
+    private final BusinessMemberRepository businessMemberRepository;
+
+    public BusinessMemberResponseDto registerBusiness(BusinessMemberRequestDto businessMemberRequestDto) {
+
+        BusinessMember existedBusinessMember = businessMemberRepository.findByBusinessNumber(businessMemberRequestDto.businessNumber());
+
+        if (existedBusinessMember != null) {
+            log.info("이미 존재하는 사업자입니다. {}", businessMemberRequestDto.businessNumber());
+            throw new BusinessException(ErrorMessage.DUPLICATE_BUSINESS_MEMBER);
+        }
+
+        // 사업 시작 날짜 파싱 - 이게 비어있으면 파싱이 안됨.
+        LocalDateTime businessStartDate;
+        try {
+            if (businessMemberRequestDto.businessStartDate() == null) {
+                throw new BusinessException(ErrorMessage.INVALID_DATE);
+            }
+            businessStartDate = LocalDateTime.parse(businessMemberRequestDto.businessStartDate(), DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"));
+        } catch (DateTimeParseException e) {
+            throw new BusinessException(ErrorMessage.INVALID_DATE);
+        }
+
+        BusinessMember businessMember = BusinessMember.of(
+                businessMemberRequestDto.businessName(),
+                businessMemberRequestDto.businessNumber(),
+                businessMemberRequestDto.businessAddress(),
+                businessStartDate,
+                businessMemberRequestDto.businessPhoneNumber(),
+                businessMemberRequestDto.businessEmail()
+        );
+
+        // BusinessMember 저장 (DB 저장 오류 처리)
+        try {
+            businessMemberRepository.save(businessMember);
+        } catch (Exception e) {
+            log.error("BusinessMember 저장 중 오류 발생: {}", e.getMessage(), e);
+            throw new BusinessException(ErrorMessage.DATABASE_ERROR);
+        }
+
+        return new BusinessMemberResponseDto(
+                businessMember.getBusinessMemberId(),
+                businessMember.getName(),
+                businessMember.getBusinessNumber(),
+                businessMember.getAddress(),
+                businessMember.getStartDate(),
+                businessMember.getPhoneNumber(),
+                businessMember.getEmail()
+        );
+    }
+}

--- a/src/main/java/com/outofcity/server/service/KakaoLoginService.java
+++ b/src/main/java/com/outofcity/server/service/KakaoLoginService.java
@@ -1,0 +1,86 @@
+package com.outofcity.server.service;
+
+import com.outofcity.server.domain.GeneralMember;
+import com.outofcity.server.dto.member.kakaologin.response.SuccessLoginResponseDto;
+import com.outofcity.server.global.exception.dto.oauth.KakaoTokenResponseDto;
+import com.outofcity.server.global.exception.dto.oauth.KakaoUserInfoResponseDto;
+import com.outofcity.server.repository.GeneralMemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+@Slf4j
+@RequiredArgsConstructor
+@Service
+@Transactional
+public class KakaoLoginService {
+
+    @Value("${kakao.client_id}")
+    private String clientId;
+
+    @Value("${kakao.redirect_uri}")
+    private String redirectUri;
+
+    private static final String KAUTH_TOKEN_URL = "https://kauth.kakao.com/oauth/token";
+    private static final String KAPI_USER_URL = "https://kapi.kakao.com/v2/user/me";
+    private final GeneralMemberRepository generalMemberRepository;
+
+    // 1. Access Token 받기
+    public String getAccessTokenFromKakao(String code){
+        KakaoTokenResponseDto kakaoTokenResponseDto = WebClient.create(KAUTH_TOKEN_URL).post()
+                .uri(uriBuilder -> uriBuilder
+                        .queryParam("grant_type", "authorization_code")
+                        .queryParam("client_id", clientId)
+                        .queryParam("redirect_uri", redirectUri)
+                        .queryParam("code", code)
+                        .build())
+                .header(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded")
+                .retrieve()
+                .bodyToMono(KakaoTokenResponseDto.class)
+                .block();
+
+        return kakaoTokenResponseDto.getAccessToken();
+    }
+
+    // 2. 사용자 정보 가져오기
+    public KakaoUserInfoResponseDto getUserInfo(String accessToken) {
+        KakaoUserInfoResponseDto userInfo = WebClient.create(KAPI_USER_URL)
+                .get()
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .retrieve()
+                .bodyToMono(KakaoUserInfoResponseDto.class)
+                .block();
+
+        return userInfo;
+    }
+
+    public SuccessLoginResponseDto findUser(KakaoUserInfoResponseDto userInfo) {
+
+        GeneralMember generalMember = generalMemberRepository.findById(userInfo.getId())
+                .orElseGet(() -> {
+                    GeneralMember newGeneralMember = GeneralMember.builder()
+                            .id(userInfo.getId())
+                            .name(userInfo.getProperties().getNickname())
+                            .rank("여행 씨앗")
+                            .profileImageUrl(userInfo.getKakaoAccount().getProfile().getProfileImageUrl())
+                            .build();
+                    return generalMemberRepository.save(newGeneralMember);
+                });
+
+        return SuccessLoginResponseDto.builder()
+                .id(generalMember.getGeneralMemberId())
+                .name(generalMember.getName())
+                .rank(generalMember.getRank())
+                .profileImageUrl(generalMember.getProfileImageUrl())
+                .email(generalMember.getEmail())
+                .build();
+    }
+}

--- a/src/main/java/com/outofcity/server/service/KakaoLoginService.java
+++ b/src/main/java/com/outofcity/server/service/KakaoLoginService.java
@@ -9,17 +9,12 @@ import com.outofcity.server.global.jwt.UserAuthentication;
 import com.outofcity.server.repository.GeneralMemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.tomcat.util.net.openssl.ciphers.Authentication;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestTemplate;
 import org.springframework.web.reactive.function.client.WebClient;
 
-import java.io.IOException;
-import java.net.http.HttpClient;
 @Slf4j
 @RequiredArgsConstructor
 @Service
@@ -37,7 +32,7 @@ public class KakaoLoginService {
     private final GeneralMemberRepository generalMemberRepository;
     private final JwtTokenProvider jwtTokenProvider;
 
-    // 1. Access Token 받기
+    // Kakao Access Token 받기
     public String getAccessTokenFromKakao(String code){
         KakaoTokenResponseDto kakaoTokenResponseDto = WebClient.create(KAUTH_TOKEN_URL).post()
                 .uri(uriBuilder -> uriBuilder
@@ -53,7 +48,7 @@ public class KakaoLoginService {
         return kakaoTokenResponseDto.getAccessToken();
     }
 
-    // 2. 사용자 정보 가져오기
+    //  사용자 정보 가져오기 - 이메일, 닉네임, 프로필 사진
     public KakaoUserInfoResponseDto getUserInfo(String accessToken) {
         KakaoUserInfoResponseDto userInfo = WebClient.create(KAPI_USER_URL)
                 .get()
@@ -72,6 +67,7 @@ public class KakaoLoginService {
                     GeneralMember newGeneralMember = GeneralMember.builder()
                             .id(userInfo.getId())
                             .name(userInfo.getProperties().getNickname())
+                            .email(userInfo.getKakaoAccount().getEmail())
                             .rank("여행 씨앗")
                             .profileImageUrl(userInfo.getKakaoAccount().getProfile().getProfileImageUrl())
                             .build();


### PR DESCRIPTION
<!-- - 
❗️ PR 제목은 아래의 형식을 맞춰주세요 
- [FEAT] 기능 추가
- [FIX] 에러 수정, 버그 수정
- [CHORE] gradle 세팅, 위의 것 이외에 거의 모든 것
- [DOCS] README, 문서
- [REFACTOR] 코드 리펙토링 (기능 변경 없이 코드만 수정할 때)
- [MODIFY] 코드 수정 (기능의 변화가 있을 때)
-->

## 📌 연관된 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

## 📝 작업 내용
<!-- 어떤 기능을 만들기 위한 내용인지 적어주세요(이미지 첨부 가능) -->
<!-- 그게 아닌 경우에는 어떤 문제를 해결하기 위한 것인지 적어주세요 -->

카카오 API를 활용해서 로그인 기능을 구현했습니다.

### 스크린샷 (선택)


## 💬리뷰 요구사항(선택)
앞으로 API에서 사용자 정보를 가져오고 싶을 때는 FE에서 전달받은 token값을 사용해서 사용자를 조회해줘야 합니다. 
예를 들면 GeneralMember generalMember = generalMemberRepository.findByToken(token, jwtTokenProvider); 이렇게 말이에요.


<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
